### PR TITLE
:recycle: fixed stylelint deprecation warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ module.exports = {
     "property-no-vendor-prefix": true,
     "no-empty-source": null,
     "no-missing-end-of-source-newline": null,
-    "at-rule-whitelist": [
+    "at-rule-allowed-list": [
       [],
       {
         severity: "error",
@@ -14,7 +14,7 @@ module.exports = {
           "this at-rule is not supported when using styled-components with React Native."
       }
     ],
-    "function-whitelist": [
+    "function-allowed-list": [
       [
         "rgb",
         "rgba",
@@ -42,7 +42,7 @@ module.exports = {
           "this function is not supported when using styled-components with React Native."
       }
     ],
-    "unit-whitelist": [
+    "unit-allowed-list": [
       ["px", "deg", "%"],
       {
         severity: "error",
@@ -50,7 +50,7 @@ module.exports = {
           "this unit is not supported when using styled-components with React Native."
       }
     ],
-    "selector-pseudo-class-whitelist": [
+    "selector-pseudo-class-allowed-list": [
       [],
       {
         severity: "error",


### PR DESCRIPTION
There were a few instances from this package which had Deprecation Warning from the Stylelint rules names.

Attached are those items, I have rename them as per the provided docs.

Please review this PR ASAP, as my CI pipelines are broken due to this.

I have verified it locally, these changes has fixed the deprecation warnings.

![Screenshot 2021-01-14 at 18 24 05](https://user-images.githubusercontent.com/27800340/104596542-eb233100-5695-11eb-8bee-500f2d01d585.png)
